### PR TITLE
Try to allow more antab time formats

### DIFF
--- a/casavlbitools/fitsidi.py
+++ b/casavlbitools/fitsidi.py
@@ -21,6 +21,7 @@ import math
 import os
 import sys
 import time as tm
+import re
 
 try:
     # Python 2
@@ -221,6 +222,36 @@ def skip_values(infp):
         continue
     return
 
+def get_timetuple(ts):
+    # ts as string with these possible formats:
+    # hh.hh      
+    # hh:mm.mm   
+    # hh:mm:ss.ss
+    # NOTE: Regexs below will match any number of decimals on the last quantity (e.g. 19.8222222 and 19.8 both work)
+    if re.match(r"[0-9]{2}\.[0-9]+", ts):
+        # hh.hh 
+        tm_hour = int(ts.split('.')[0])
+        tm_min = math.modf(60*float(ts.split('.')[1]))
+        tm_sec = int(60 * tm_min[0])
+        tm_min = int(tm_min[1])
+    elif re.match(r"[0-9]{2}:[0-9]{2}\.[0-9]+", ts):
+        # hh:mm.mm 
+        tm_hour = int(ts.split(':')[0])
+        tm_min = math.modf(float(ts.split(':')[1]))
+        tm_sec = int(60 * tm_min[0])
+        tm_min = int(tm_min[1])
+    elif re.match(r"[0-9]{2}:[0-9]{2}:[0-9]{2}$", ts):
+        # hh:mm:ss
+        tm_hour = int(ts.split(':')[0])
+        tm_min = int(ts.split(':')[1])
+        tm_sec = int(ts.split(':')[2])
+    elif re.match(r"[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+", ts):
+        # hh:mm:ss.ss
+        tm_hour = int(ts.split(':')[0])
+        tm_min = int(ts.split(':')[1])
+        tm_sec = float(ts.split(':')[2])
+    return tm_hour, tm_min, tm_sec
+
 def process_values(infp, keys, pols, idi, data):
     year = tm.gmtime(idi.reftime).tm_year
     antenna_name = find_antenna(keys[0], ['SRC/SYS'])
@@ -256,10 +287,8 @@ def process_values(infp, keys, pols, idi, data):
         if len(fields) > 1:
             tm_year = year
             tm_yday = int(fields[0])
-            tm_hour = int(fields[1].split(':')[0])
-            tm_min = math.modf(float(fields[1].split(':')[1]))
-            tm_sec = int(60 * tm_min[0])
-            tm_min = int(tm_min[1])
+            # Get timestamp data depending on data format
+            tm_hour, tm_min, tm_sec = get_timetuple(fields[1])
             t = "%dy%03dd%02dh%02dm%02ds" % \
                 (tm_year, tm_yday, tm_hour, tm_min, tm_sec)
             t = tm.mktime(tm.strptime(t, "%Yy%jd%Hh%Mm%Ss"))


### PR DESCRIPTION
This patch should (tested locally with time formats of style HH:MM:SS.ss) allow more time formats for antab files, i.e. fix #2.