### PR TITLE
Breaking if timerange=0 in .uvflg

### DIFF
--- a/casavlbitools/fitsidi.py
+++ b/casavlbitools/fitsidi.py
@@ -708,6 +708,8 @@ def convert_flags(infile, idifiles, outfp=sys.stdout, outfile=None):
         timerange = flag['TIMERANG']
         if timerange == [0.0, 0.0, 0.0, 0.0, 400.0, 0.0, 0.0, 0.0]:
             timerange = ""
+        elif isinstance(timerange, float) or isinstance(timerange, int):
+            timerange = ""
         else:
             year = datetime.datetime(first_date.year, 1, 1)
             date1 = year + datetime.timedelta(timerange[0] - 1)


### PR DESCRIPTION
One can define timerange=0 (standard value in AIPS) for a given uv flag.
But the script breaks as it was assuming that it contains a list in that case. This fixes this.